### PR TITLE
Minor change on 400(0) comment

### DIFF
--- a/04-guides/06-scripting.md
+++ b/04-guides/06-scripting.md
@@ -31,7 +31,7 @@ if (ctx.isClient) { // ctx Variable contains all Context information
 ```js
 var data = ctx.data;
 if (data.password.iv !== data.passwordConfirm.iv) {
-    // Tell Squidex to return 4000 (Bad Request)
+    // Tell Squidex to return a 400 (Bad Request)
     reject('Passwords must be the same');
 }
 ```


### PR DESCRIPTION
Document referred to a 4000 instead of 400 status. Added 'a' to match syntax of similar comments.